### PR TITLE
Revert "Bump docker/bake-action from 2.3.0 to 3.0.1"

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -44,7 +44,7 @@ jobs:
           wait-interval: 20
       -
         name: Build and push
-        uses: docker/bake-action@v3.0.1
+        uses: docker/bake-action@v2.3.0
         with:
           files: build/docker-bake.hcl
           push: true


### PR DESCRIPTION
Reverts N0rthernL1ghts/wordpress#15 - Troubleshooting issue with actions 